### PR TITLE
Sanitize Anime API's

### DIFF
--- a/src/api/anime/1AnimeApi.txt
+++ b/src/api/anime/1AnimeApi.txt
@@ -26,7 +26,7 @@ Date checked: 12/06/2023
         //https://docs.nekos.best/
         {name:'NekosBest'},
 
-        //(Broke)https://ghibliapi.herokuapp.com/
+        //https://ghibliapi.vercel.app/
         {name:'Studio Ghibli'},
       
 

--- a/src/api/anime/1AnimeApi.txt
+++ b/src/api/anime/1AnimeApi.txt
@@ -1,12 +1,9 @@
+Date checked: 12/06/2023
 {name:'Anime',
     list: [
        ,
-        //https://wiki.anidb.net/HTTP_API_Definition
-        {name:'AniDB'},
-
         //https://github.com/AniList/ApiV2-GraphQL-Docs
         {name:'AniList'},
-
 
         //https://github.com/RocktimSaikia/anime-chan
         {name:'AnimeChan'},
@@ -20,26 +17,14 @@
         //https://catboys.com/api
         {name:'Catboy'},
 
-        //https://danbooru.donmai.us/wiki_pages/help:api
-        {name:'Danbooru Anime'},
-
         //https://jikan.moe/
         {name:'Jikan'},
 
         //https://kitsu.docs.apiary.io/#
         {name:'Kitsu'},
 
-        //https://rapidapi.com/pierre.carcellermeunier/api/mangapi3/
-        {name:'Mangapi'},
-
-        //https://myanimelist.net/clubs.php?cid=13727
-        {name:'MyAnimeList'},
-
         //https://docs.nekos.best/
         {name:'NekosBest'},
-
-        //https://shikimori.one/api/doc
-        {name:'Shikimori'},
 
         //(Broke)https://ghibliapi.herokuapp.com/
         {name:'Studio Ghibli'},


### PR DESCRIPTION
## Description

Removed list of Anime API's that weren't free, required an API key, signup or contained inappropriate content.
Changed Studio Ghibli API url.

## Related Issues

#21

## Checklist

- [ x ] I have tested my changes locally.
- [ x ] I have added necessary documentation or updated existing documentation.
- [ x ] My code follows the project's coding conventions and style guidelines.
- [ ] All tests pass successfully.
- [ ] I have added/updated relevant unit tests.

## Additional Notes

At the moment of this pull request AnimeChan API isn't working.
I changed the broken Studio Ghibli API url to https://ghibliapi.vercel.app/ which satisfies the checklist requirements (it's free, doesn't require an API key or signup).