### PR TITLE
chore: add default values for props of btnrouting component

### DIFF
--- a/src/components/BtnRouting.js
+++ b/src/components/BtnRouting.js
@@ -7,9 +7,9 @@ import { Box, Button, Typography } from "@mui/material";
 const BtnRouting = ({
   btnName,
   navigateTo,
-  backgroundColor,
-  textColor,
-  amount,
+  backgroundColor = "#0077ba",
+  textColor = "white",
+  amount = 0
 }) => {
   const navigate = useNavigate();
   const hoverShadow = function () {


### PR DESCRIPTION
## Description

Set default values for the backgroundColor, textColor, and amount props in the BtnRouting component to provide a better default user experience, considering Material-UI styles.

## Related Issues

#60

## Checklist

- [x] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [x] My code follows the project's coding conventions and style guidelines.
- [x] All tests pass successfully.
- [ ] I have added/updated relevant unit tests.

## Additional Notes

Hope this solves the issue (:

If something needs to be changed or if I misunderstood the issue, please let me know.
