### PR TITLE
Add tooltips for header elements

### DIFF
--- a/src/core/header/Header.js
+++ b/src/core/header/Header.js
@@ -9,6 +9,7 @@ import {
   Stack,
   Menu,
   MenuItem,
+  Tooltip,
 } from "@mui/material";
 
 import BuildIcon from "@mui/icons-material/Build";
@@ -115,16 +116,22 @@ Handles the click event of the "Docs" button and navigates to the "Docs" route.
             ) : (
               <Hidden smDown>
                 <Stack direction="row" alignItems="center">
-                  <IconButton onClick={handleToolsClick} edge="start">
-                    <BuildIcon sx={{ margin: 1 }} />
-                    <Typography variant="body1">Tools</Typography>
-                  </IconButton>
-                  <IconButton onClick={handleDocsClick} edge="start">
-                    <DescriptionIcon sx={{ margin: 1 }} />
-                    <Typography variant="body1">Docs</Typography>
-                  </IconButton>
+                  <Tooltip title="Go to Tools" placement="bottom">
+                    <IconButton onClick={handleToolsClick} edge="start">
+                        <BuildIcon sx={{ margin: 1 }} />
+                        <Typography variant="body1">Tools</Typography>
+                    </IconButton>
+                  </Tooltip>
+                  <Tooltip title="View Documentation" placement="bottom">
+                    <IconButton onClick={handleDocsClick} edge="start">
+                      <DescriptionIcon sx={{ margin: 1 }} />
+                      <Typography variant="body1">Docs</Typography>
+                    </IconButton>
+                  </Tooltip>
                   <Divider orientation="vertical" flexItem sx={{ margin: 1 }} />
-                  <Switch checked={darkMode} onChange={handleSwitchToggle} />
+                  <Tooltip title={`Switch to ${darkMode ? "light" : "dark"} mode`} placement="bottom">
+                    <Switch checked={darkMode} onChange={handleSwitchToggle} />
+                  </Tooltip>
                   <Typography variant="body1">Theme</Typography>
                 </Stack>
               </Hidden>


### PR DESCRIPTION
## Description

Added tooltips for elements in the header, i.e the theme toggle switch and tools, docs buttons.

## Related Issues

For #76 

## Checklist

- [x] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [x] My code follows the project's coding conventions and style guidelines.
- [ ] All tests pass successfully.
- [ ] I have added/updated relevant unit tests.

## Additional Notes

I have not added tooltips for the mobile view since it did not feel necessary, but let me know if you need to me add for that as well.